### PR TITLE
Prevent duplicate drag listeners

### DIFF
--- a/script.js
+++ b/script.js
@@ -14,6 +14,9 @@ document.addEventListener("DOMContentLoaded", () => {
   function attachDragEvents(el) {
     el.setAttribute("draggable", "true");
 
+    if (el.dataset.dragEventsAttached === "true") return;
+    el.dataset.dragEventsAttached = "true";
+
     el.addEventListener("dragstart", () => {
       draggedElement = el;
       const parentBank = el.closest(".drag-items");

--- a/script2.js
+++ b/script2.js
@@ -14,6 +14,9 @@ document.addEventListener("DOMContentLoaded", () => {
   function attachDragEvents(el) {
     el.setAttribute("draggable", "true");
 
+    if (el.dataset.dragEventsAttached === "true") return;
+    el.dataset.dragEventsAttached = "true";
+
     el.addEventListener("dragstart", () => {
       draggedElement = el;
       const parentBank = el.closest(".drag-items");


### PR DESCRIPTION
## Summary
- check if a draggable item already has listeners before adding them
- same fix applied to `script2.js`

## Testing
- `node verify.js`

------
https://chatgpt.com/codex/tasks/task_e_686540696cc8832eb04c11958e240b6f